### PR TITLE
Fix UVs with zero size in UDIM

### DIFF
--- a/char.blend
+++ b/char.blend
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d7c14d633aa6cf3a84f783d9ca5ccd94594e58d38370084d222e1a09116452cb
-size 23868338
+oid sha256:ad219fcde254efed76d7a5d57f186f6e5ac42eb779e8f36281ce4ba9a5da23be
+size 23870466


### PR DESCRIPTION
This should solve transfer issue with [Mesh data transfer add-on](https://github.com/hannesdelbeke/mesh-data-transfer) working in uv space, causing NAN propagation. Also generally better practice.